### PR TITLE
Add test to illustrate case sensitivity issue on table names

### DIFF
--- a/t/sxql.lisp
+++ b/t/sxql.lisp
@@ -9,7 +9,7 @@
                           :is-error))
 (in-package :t.sxql)
 
-(plan 63)
+(plan 64)
 
 (defmacro is-mv (test result &optional desc)
   `(is (multiple-value-list (yield ,test))
@@ -289,6 +289,12 @@
 (is-mv (from :table)
        '("FROM `table`" nil))
 
+(is-mv (from :|Table|)
+       '("FROM `Table`" nil))
+
+;; 20141231 - m@ahungry.com - These above tests now pass, but all caps will fail
+;; There likely isn't an easy work around, but I think all cap table names is rare
+;; enough that it won't matter (maybe downcase can be something configured)
 (is-mv (from :|TABLE|)
        '("FROM `TABLE`" nil))
 

--- a/t/sxql.lisp
+++ b/t/sxql.lisp
@@ -9,7 +9,7 @@
                           :is-error))
 (in-package :t.sxql)
 
-(plan 61)
+(plan 63)
 
 (defmacro is-mv (test result &optional desc)
   `(is (multiple-value-list (yield ,test))
@@ -284,5 +284,12 @@
 (let ((primary-key :id))
   (is-mv (primary-key primary-key)
          '("PRIMARY KEY (`id`)" nil)))
+
+;; 20141231 - m@ahungry.com - Add tests to illustrate case sensitivity issue
+(is-mv (from :table)
+       '("FROM `table`" nil))
+
+(is-mv (from :|TABLE|)
+       '("FROM `TABLE`" nil))
 
 (finalize)


### PR DESCRIPTION
The following tests illustrate the table name case sensitivity issue - you will find the first passes as expected, but the second test fails (at least under SBCL, have not tested under any other implementations).