### PR TITLE
Allow arbitrary boolean expressions in join clauses.

### DIFF
--- a/src/clause.lisp
+++ b/src/clause.lisp
@@ -72,7 +72,7 @@
                          (eql :left)
                          (eql :right)
                          (eql :full)))
-  (on nil :type (or null =-op))
+  (on nil :type (or null sql-expression))
   (using nil :type (or null sql-symbol sql-list)))
 
 @export

--- a/src/sxql.lisp
+++ b/src/sxql.lisp
@@ -197,7 +197,10 @@
   `(make-clause :join ,(expand-op table)
                 :kind ,kind
                 ,@(if on
-                      `(:on (make-op ,@on))
+                      `(:on ,(if (and (listp on)
+                                      (keywordp (car on)))
+                                 (expand-op on)
+                                 `,on))
                       nil)
                 ,@(if using
                       `(:using ',using)


### PR DESCRIPTION
This uses the same approach as the SXQL:WHERE macro, so it should support
sxql-dsl expressions (e.g. '(:and :foo :bar)) as well as regular forms to
be evaluated normally.

This should resolve #17.