### PR TITLE
Support MySQL's INSERT ... ON DUPLICATE KEY UPDATE syntax.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -389,6 +389,22 @@ Creates a SELECT query. It takes a field (or a list of fields) and SQL Clauses.
 ;=> #<SXQL-STATEMENT: ALTER TABLE `user` RENAME TO `users`>
 ```
 
+### on-duplicate-key-update
+
+Support MySQL's `INSERT ... ON DUPLICATE KEY UPDATE` syntax.
+
+```common-lisp
+(on-duplicate-key-update :age '(:+ :age 1))
+;=> #<SXQL-CLAUSE: ON DUPLICATE KEY UPDATE `age` = (`age` + 1)>
+
+(insert-into :person
+  (set= :sex "male"
+        :age 25
+        :name "Eitaro Fukamachi")
+  (on-duplicate-key-update :age '(:+ :age 1)))
+;=> #<SXQL-STATEMENT: INSERT INTO `person` (`sex`, `age`, `name`) VALUES ('male', 25, 'Eitaro Fukamachi') ON DUPLICATE KEY UPDATE `age` = (`age` + 1)>
+```
+
 ## SQL Operators
 
 * :not

--- a/src/clause.lisp
+++ b/src/clause.lisp
@@ -272,6 +272,27 @@
    "DROP PRIMARY KEY"
    nil))
 
+(defstruct (on-duplicate-key-update-clause (:include sql-clause (name "ON DUPLICATE KEY UPDATE"))
+                                           (:constructor %make-on-duplicate-key-update-clause (&rest args)))
+  (args nil :type (and proper-list
+                     (satisfies sql-expression-list-p))))
+
+(defun make-on-duplicate-key-update-clause (&rest args)
+  (unless (and (cdr args)
+               (= (mod (length args) 2) 0))
+    ;; TODO: raise an error.
+    )
+  (apply #'%make-on-duplicate-key-update-clause args))
+
+(defmethod yield ((clause on-duplicate-key-update-clause))
+  (labels ((yield-arg (arg)
+             (if arg
+                 (yield arg)
+                 "NULL")))
+    (with-yield-binds
+      (format nil "ON DUPLICATE KEY UPDATE ~{~A = ~A~^, ~}"
+              (mapcar #'yield-arg (on-duplicate-key-update-clause-args clause))))))
+
 (defun find-make-clause (clause-name &optional (package *package*))
   (find-constructor clause-name #.(string :-clause)
                     :package package))

--- a/src/sxql.lisp
+++ b/src/sxql.lisp
@@ -284,6 +284,10 @@
 (defun drop-primary-key ()
   (make-clause :drop-primary-key))
 
+@export
+(defmacro on-duplicate-key-update (&rest args)
+  `(make-clause :on-duplicate-key-update ,@(mapcar #'expand-op args)))
+
 
 ;;
 ;; Types

--- a/src/sxql.lisp
+++ b/src/sxql.lisp
@@ -189,8 +189,8 @@
   (make-clause :offset offset))
 
 @export
-(defun set= (&rest args)
-  (apply #'make-clause :set= args))
+(defmacro set= (&rest args)
+  `(make-clause :set= ,@(mapcar #'expand-op args)))
 
 @export
 (defmacro join (table &key (kind :inner) on using)

--- a/t/clause.lisp
+++ b/t/clause.lisp
@@ -10,7 +10,7 @@
                           :is-error))
 (in-package :t.sxql.clause)
 
-(plan 55)
+(plan 57)
 
 (ok (make-clause :where (make-op := :a 10)))
 (is (multiple-value-list
@@ -230,6 +230,12 @@
        :unique t)))
     '("`email` TEXT NOT NULL UNIQUE" nil)
     "column-definition")
+
+(is (multiple-value-list
+     (yield
+      (make-clause :on-duplicate-key-update :a 1 :b 2)))
+    '("ON DUPLICATE KEY UPDATE `a` = ?, `b` = ?" (1 2))
+    "on-duplicate-key-update")
 
 (diag "sql-compile clause")
 

--- a/t/sxql.lisp
+++ b/t/sxql.lisp
@@ -9,7 +9,7 @@
                           :is-error))
 (in-package :t.sxql)
 
-(plan 63)
+(plan 64)
 
 (defmacro is-mv (test result &optional desc)
   `(is (multiple-value-list (yield ,test))
@@ -140,6 +140,14 @@
          (select (:name :sex) (from :person_tmp)))
        '("INSERT INTO `person` (`name`, `sex`) SELECT `name`, `sex` FROM `person_tmp`" nil)
        "INSERT INTO ... SELECT")
+
+(is-mv (insert-into :person
+         (set= :sex "male"
+               :age 25
+               :name "Eitaro Fukamachi")
+         (on-duplicate-key-update :age (:+ :age 1)))
+       '("INSERT INTO `person` (`sex`, `age`, `name`) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE `age` = (`age` + ?)" ("male" 25 "Eitaro Fukamachi" 1))
+       "INSERT ... ON DUPLICATE KEY UPDATE")
 
 (is-mv (update :person
                (set= :name "Eitaro Fukamachi"

--- a/t/sxql.lisp
+++ b/t/sxql.lisp
@@ -9,7 +9,7 @@
                           :is-error))
 (in-package :t.sxql)
 
-(plan 64)
+(plan 65)
 
 (defmacro is-mv (test result &optional desc)
   `(is (multiple-value-list (yield ,test))
@@ -157,6 +157,13 @@
                (limit 5))
        '("UPDATE `person` SET `name` = ?, `sex` = ? WHERE (`age` > ?) ORDER BY `id` LIMIT 5"
          ("Eitaro Fukamachi" "male" 20))
+       "UPDATE")
+
+(is-mv (update :person
+         (set= :age (:+ :age 1))
+         (where (:like :name "Eitaro %")))
+       '("UPDATE `person` SET `age` = (`age` + ?) WHERE (`name` LIKE ?)"
+         (1 "Eitaro %"))
        "UPDATE")
 
 (is-mv (delete-from :person


### PR DESCRIPTION
Add `on-duplicate-key-update` clause to support MySQL's  `INSERT ... ON DUPLICATE KEY UPDATE` syntax.

13.2.5.3 INSERT ... ON DUPLICATE KEY UPDATE Syntax
http://dev.mysql.com/doc/refman/5.7/en/insert-on-duplicate.html

The number of tests in t/clause.lisp was wrong before this change so it should be `(plan 57)` now.