### PR TITLE
Add :a> and :a< operators

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -436,6 +436,7 @@ Support MySQL's `INSERT ... ON DUPLICATE KEY UPDATE` syntax.
 * :distinct
 * :=, :!=
 * :<, :>, :<= :>=
+* :a<, :a>
 * :as
 * :in, :not-in
 * :like

--- a/src/operator.lisp
+++ b/src/operator.lisp
@@ -55,6 +55,8 @@
 (define-op (:> infix-op))
 (define-op (:<= infix-op))
 (define-op (:>= infix-op))
+(define-op (:a< infix-op :sql-op-name "@<"))
+(define-op (:a> infix-op :sql-op-name "@>"))
 (define-op (:as infix-splicing-op))
 (define-op (:in infix-list-op))
 (define-op (:not-in infix-list-op))

--- a/t/operator.lisp
+++ b/t/operator.lisp
@@ -102,6 +102,20 @@
     "<=")
 
 (is (multiple-value-list
+     (yield (make-op :a<
+                     (make-sql-variable 1)
+                     (make-sql-variable 1))))
+    (list "(? @< ?)" '(1 1))
+    "@<")
+
+(is (multiple-value-list
+     (yield (make-op :a>
+                     (make-sql-variable 1)
+                     (make-sql-variable 1))))
+    (list "(? @> ?)" '(1 1))
+    "@>")
+
+(is (multiple-value-list
      (yield (make-op :as
                          (make-sql-symbol "table-name")
                          (make-sql-symbol "a"))))


### PR DESCRIPTION
Hello, I've added operators for PostgreSQL array contains functions. Is it too specific for PostgreSQL and shouldn't be in sxql?