### PR TITLE
Add support for "FOR UPDATE" clause of SELECT.

### DIFF
--- a/src/statement.lisp
+++ b/src/statement.lisp
@@ -20,6 +20,7 @@
                 :group-by-clause
                 :having-clause
                 :returning-clause
+                :updatability-clause
                 :order-by-clause
                 :limit-clause
                 :offset-clause)
@@ -55,7 +56,8 @@
                        returning-clause
                        order-by-clause
                        limit-clause
-                       offset-clause))
+                       offset-clause
+                       updatability-clause))
       (setf (gethash clause hash) i))
     hash))
 
@@ -84,6 +86,7 @@
                                                                     order-by-clause
                                                                     limit-clause
                                                                     offset-clause
+                                                                    updatability-clause
                                                                   &aux
                                                                     (clause-order
                                                                      (sort-clause-types
@@ -103,7 +106,8 @@
   (returning-clause nil)
   (order-by-clause nil)
   (limit-clause nil)
-  (offset-clause nil))
+  (offset-clause nil)
+  (updatability-clause nil))
 
 @export
 (defun compute-select-statement-children (select-statement)
@@ -118,7 +122,8 @@
                                       returning-clause
                                       order-by-clause
                                       limit-clause
-                                      offset-clause))
+                                      offset-clause
+                                      updatability-clause))
                    (collect (cons type
                                   (or (position type (select-statement-clause-order select-statement)
                                                 :test #'eq)

--- a/src/sxql.lisp
+++ b/src/sxql.lisp
@@ -193,6 +193,13 @@
                      `,expression)))
 
 @export
+(defmacro for (update-type &key of nowait)
+  (let ((ident-list (if (keywordp of)
+                        `(list ,of)
+                        `(quote ,of))))
+    `(make-clause :updatability ,update-type :of ,ident-list :nowait ,nowait)))
+
+@export
 (defun limit (count1 &optional count2)
   (apply #'make-clause :limit `(,count1 ,@(and count2 (list count2)))))
 

--- a/t/clause.lisp
+++ b/t/clause.lisp
@@ -105,7 +105,7 @@
     (list "FOR UPDATE OF `hoge`, `piyo` NOWAIT" nil))
 (is (multiple-value-list
      (yield (make-clause :updatability :update :nowait t)))
-    (list "FOR UPDATE NOWAIT"))
+    (list "FOR UPDATE NOWAIT" nil))
 
 (ok (make-clause :limit (make-sql-variable 1)) "LIMIT")
 (ok (make-clause :limit (make-sql-variable 0) (make-sql-variable 10)))

--- a/t/clause.lisp
+++ b/t/clause.lisp
@@ -88,6 +88,25 @@
       (make-clause :returning (make-sql-symbol "id"))))
     (list "RETURNING `id`" nil))
 
+(ok (make-clause :updatability :update) "FOR UPDATE")
+(ok (make-clause :updatability :update :of '(:hoge :piyo)) "FOR UPDATE OF")
+(ok (make-clause :updatability :update :of '(:hoge :piyo) :nowait t) "FOR UPDATE OF NOWAIT")
+(is (multiple-value-list
+     (yield (make-clause :updatability :update)))
+    (list "FOR UPDATE" nil))
+(is (multiple-value-list
+     (yield (make-clause :updatability :share)))
+    (list "FOR SHARE" nil))
+(is (multiple-value-list
+     (yield (make-clause :updatability :update :of '(:hoge :fuga.piyo))))
+    (list "FOR UPDATE OF `hoge`, `fuga`.`piyo`" nil))
+(is (multiple-value-list
+     (yield (make-clause :updatability :update :of '(:hoge :piyo) :nowait t)))
+    (list "FOR UPDATE OF `hoge`, `piyo` NOWAIT" nil))
+(is (multiple-value-list
+     (yield (make-clause :updatability :update :nowait t)))
+    (list "FOR UPDATE NOWAIT"))
+
 (ok (make-clause :limit (make-sql-variable 1)) "LIMIT")
 (ok (make-clause :limit (make-sql-variable 0) (make-sql-variable 10)))
 (is (multiple-value-list

--- a/t/statement.lisp
+++ b/t/statement.lisp
@@ -48,6 +48,19 @@
                                          (make-sql-symbol "a")))))
     (list "SELECT `a`, ? FROM `table` ORDER BY `a`" '(1)))
 
+(ok (make-statement :select
+                    (make-clause :fields :a)
+                    (make-clause :from (make-sql-symbol "table"))
+                    (make-clause :order-by (make-sql-symbol "a"))
+                    (make-clause :updatability :update :of (make-sql-symbol "a"))))
+(is (multiple-value-list
+     (yield (make-statement :select
+                            (make-clause :fields :a)
+                            (make-clause :from (make-sql-symbol "table"))
+                            (make-clause :order-by (make-sql-symbol "a"))
+                            (make-clause :updatability :update :of (make-sql-symbol "a") :nowait t))))
+    (list "SELECT `a` FROM `table` ORDER BY `a` FOR UPDATE OF `a` NOWAIT" nil))
+
 (is (multiple-value-list
      (yield (make-statement :select
                             (make-clause :fields :*)


### PR DESCRIPTION
This adds support for "SELECT...FOR UPDATE" and "SELECT...FOR SHARE"
statements, with an optional list of tables or columns, and an optional
NOWAIT keyword. This conforms to the ODBC Extended Syntax for select
statements, and matches PostgreSQL's "FOR UPDATE" clause too.

I'm fairly, but not completely, sure that I did this correctly. It should mostly
match what the WHERE/JOIN clauses do, but if I missed something important
please let me know. "FOR" seemed like an awfully general name for the macro,
so if you've got a better idea for that I'd be happy to change it.
