### PR TITLE
Add support for PostgreSQL IS DISTINCT FROM

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -443,6 +443,7 @@ Support MySQL's `INSERT ... ON DUPLICATE KEY UPDATE` syntax.
 * :and, :or
 * :+, :-, :* :/ :%
 * :raw
+* :is-distinct-from, :is-not-distinct-from (Postgres)
 
 ## Set a quote character
 

--- a/src/operator.lisp
+++ b/src/operator.lisp
@@ -62,6 +62,8 @@
 (define-op (:in infix-list-op))
 (define-op (:not-in infix-list-op))
 (define-op (:like infix-op))
+(define-op (:is-distinct-from infix-op))
+(define-op (:is-not-distinct-from infix-op))
 
 (define-op (:or conjunctive-op))
 (define-op (:and conjunctive-op))

--- a/t/operator.lisp
+++ b/t/operator.lisp
@@ -172,6 +172,20 @@
                    (make-sql-variable "extra argument"))
           'program-error)
 
+(is (multiple-value-list
+     (yield (make-op :is-distinct-from
+                         (make-sql-variable 1 )
+                         (make-sql-variable 1))))
+    (list "(? IS DISTINCT FROM ?)" '(1 1))
+    "IS DISTINCT FROM")
+
+(is (multiple-value-list
+     (yield (make-op :is-not-distinct-from
+                         (make-sql-variable 1 )
+                         (make-sql-variable 1))))
+    (list "(? IS NOT DISTINCT FROM ?)" '(1 1))
+    "IS NOT DISTINCT FROM")
+
 (diag "conjunctive-op")
 
 (is (multiple-value-list


### PR DESCRIPTION
As well as IS NOT DISTINCT FROM.  These operators allow for
(in)equality checks, handling NULL as not equal to anything but
itself.