### PR TITLE
Add support for PostgreSQL ON CONFLICT

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -428,6 +428,42 @@ Support MySQL's `INSERT ... ON DUPLICATE KEY UPDATE` syntax.
 ;=> #<SXQL-STATEMENT: INSERT INTO `person` (`sex`, `age`, `name`) VALUES ('male', 25, 'Eitaro Fukamachi') ON DUPLICATE KEY UPDATE `age` = (`age` + 1)>
 ```
 
+### on-coflict-do-nothing
+
+Support PostgreSQL's `INSERT ... ON CONFLICT DO NOTHING` syntax.
+
+```common-lisp
+(on-conflict-do-nothing)
+;=> #<SXQL-CLAUSE: ON CONFLICT DO NOTHING>
+
+(on-conflict-do-nothing :index_name)
+;=> #<SXQL-CLAUSE: ON CONFLICT ON CONSTRAINT index_name DO NOTHING>
+
+(on-conflict-do-nothing '(:column1 :column2 :column3))
+;=> #<SXQL-CLAUSE: ON CONFLICT (column1, column2, column3) DO NOTHING>
+```
+
+### on-coflict-do-update
+
+Support PostgreSQL's `INSERT ... ON CONFLICT ... DO UPDATE` syntax.
+
+```common-lisp
+(on-conflict-do-update :index_name (set= :x 1 :y 2))
+;=> #<SXQL-CLAUSE: ON CONFLICT ON CONSTRAINT index_name DO UPDATE SET x = 1, y = 2>
+
+(on-conflict-do-update '(:column1 :column2 :column3) (set= :x 1 :y 2))
+;=> #<SXQL-CLAUSE: ON CONFLICT (column1, column2, column3) DO UPDATE SET x = 1, y = 2>
+
+(insert-into :person
+  (set= :sex "male"
+        :age 25
+        :name "Eitaro Fukamachi")
+  (on-conflict-do-update '(:name)
+                         (set= :age (:+ :age 1))
+                         (where (:< :age 99))))
+;=> #<SXQL-STATEMENT: INSERT INTO person (sex, age, name) VALUES ('male', 25, 'Eitaro Fukamachi') ON CONFLICT (name) DO UPDATE SET age = (age + 1) WHERE (age < 99)>
+```
+
 ## SQL Operators
 
 * :not

--- a/src/sxql.lisp
+++ b/src/sxql.lisp
@@ -323,6 +323,17 @@
 (defmacro on-duplicate-key-update (&rest args)
   `(make-clause :on-duplicate-key-update ,@(mapcar #'expand-op args)))
 
+@export
+(defmacro on-conflict-do-nothing (&optional (conflict-target nil))
+  `(make-clause :on-conflict-do-nothing ,conflict-target))
+
+@export
+(defmacro on-conflict-do-update (conflict-target update-set &optional where-condition)
+  `(make-clause :on-conflict-do-update
+                ,conflict-target
+                ,update-set
+                ,where-condition))
+
 
 ;;
 ;; Types


### PR DESCRIPTION
For ON CONFLICT DO (NOTHING/UPDATE), implemented support for
constraints as a collection of columns, e.g.:

ON CONFLICT (x, y, z) DO ...

and as a named constraint, e.g.:

ON CONFLICT ON CONSTRAINT table_pkey DO ...

I didn't implement the other ways to specify the conclict target
because I don't understand them enough to do so.