### PR TITLE
fix yield for infix-op

### DIFF
--- a/src/sql-type.lisp
+++ b/src/sql-type.lisp
@@ -326,13 +326,15 @@
             binds)))
 
 (defmethod yield ((op infix-op))
-  (with-yield-binds
-    (format nil "(~A ~A ~A)"
-            (yield (infix-op-left op))
-            (sql-op-name op)
-            (if (sql-statement-p (infix-op-right op))
-                (format nil "(~A)" (yield (infix-op-right op)))
-                (yield (infix-op-right op))))))
+  (flet ((f (left-or-right)
+           (if (sql-statement-p left-or-right)
+               (format nil "(~A)" (yield left-or-right))
+               (yield left-or-right))))
+    (with-yield-binds
+      (format nil "(~A ~A ~A)"
+              (f (infix-op-left op))
+              (sql-op-name op)
+              (f (infix-op-right op))))))
 
 (defmethod yield ((op infix-splicing-op))
   (with-yield-binds

--- a/t/sxql.lisp
+++ b/t/sxql.lisp
@@ -201,6 +201,10 @@
          (10 100))
        "UNION ALL")
 
+(is-mv (where `(:<= ,(select :* (from :table)) :value))
+       '("WHERE ((SELECT * FROM `table`) <= `value`)"
+         nil))
+
 (is-mv (create-table :enemy
         ((name :type 'string
                :primary-key t)


### PR DESCRIPTION
infix-opのyieldで左辺にselectがある場合に間違ったsqlを出していました

```
(yield (where `(:<= ,(select :* (from :table)) :value)))
```

修正前
```
"WHERE (SELECT * FROM `table` <= `value`)"
```

修正後
```
"WHERE ((SELECT * FROM `table`) <= `value`)"
```