### PR TITLE
Support rename column clause

### DIFF
--- a/src/clause.lisp
+++ b/src/clause.lisp
@@ -271,6 +271,12 @@
               ((alter-column-clause-not-null clause) " SET NOT NULL")
               (T " DROP NOT NULL")))))
 
+(defmethod yield ((clause rename-column-clause))
+  (with-yield-binds
+    (format nil "RENAME COLUMN ~A TO ~A"
+            (yield (rename-column-clause-old-column-name clause))
+            (yield (rename-column-clause-new-column-name clause)))))
+
 (defstruct (change-column-clause (:include column-modifier-clause (name "CHANGE COLUMN"))
                                  (:constructor make-change-column-clause (old-column-name column-definition
                                                                           &key after first

--- a/src/clause.lisp
+++ b/src/clause.lisp
@@ -251,6 +251,11 @@
   column-name type set-default drop-default
   (not-null :unspecified))
 
+(defstruct (rename-column-clause (:include sql-clause (name "RENAME COLUMN"))
+                                 (:constructor make-rename-column-clause (old-column-name new-column-name)))
+  "Generates a RENAME COLUMN clause. All MySQL/PostgreSQL/SQLite support this to rename a column. Notice that SQLite before 3.25.0 doesn't support RENAME COLUMN."
+  old-column-name new-column-name)
+
 (defmethod yield ((clause alter-column-clause))
   (with-yield-binds
     (format nil "ALTER COLUMN ~A~:[~; TYPE ~:*~A~]~:[~; SET DEFAULT ~:*~A~]~:[~; DROP DEFAULT~]~A"

--- a/src/sxql.lisp
+++ b/src/sxql.lisp
@@ -315,6 +315,11 @@
          args))
 
 @export
+(defun rename-column (old-column-name new-column-name)
+  "Notice that SQLite before 3.25.0 doesn't support this RENAME COLUMN clause."
+  (make-clause :rename-column old-column-name new-column-name))
+
+@export
 (defun rename-to (new-table-name)
   (make-clause :rename-to new-table-name))
 

--- a/t/clause.lisp
+++ b/t/clause.lisp
@@ -10,7 +10,7 @@
                           :is-error))
 (in-package :t.sxql.clause)
 
-(plan 59)
+(plan 60)
 
 (ok (make-clause :where (make-op := :a 10)))
 (is (multiple-value-list
@@ -216,6 +216,10 @@
 (is (multiple-value-list
      (yield (make-clause :alter-column :profile :not-null t)))
     (list "ALTER COLUMN `profile` SET NOT NULL" nil))
+
+(is (multiple-value-list
+     (yield (make-clause :rename-column :uuid :id)))
+    (list "RENAME COLUMN `uuid` TO `id`" nil))
 
 (is (multiple-value-list
      (yield (make-clause :drop-column

--- a/t/statement.lisp
+++ b/t/statement.lisp
@@ -11,7 +11,7 @@
                           :is-error))
 (in-package :t.sxql.statement)
 
-(plan 19)
+(plan 20)
 
 (diag "statement")
 
@@ -186,6 +186,11 @@
               (make-clause :add-column :status
                            :type '(:enum ("temporary" "registered" "banned"))))))
     '("ALTER TABLE `tweet` ADD COLUMN `status` ENUM('temporary', 'registered', 'banned')" nil))
+
+(is (multiple-value-list
+     (yield (make-statement :alter-table :tweet
+              (make-clause :rename-column :uuid :id))))
+    '("ALTER TABLE `tweet` RENAME COLUMN `uuid` TO `id`" nil))
 
 (is (multiple-value-list
      (yield (make-statement :create-index :index_name

--- a/t/sxql.lisp
+++ b/t/sxql.lisp
@@ -9,7 +9,7 @@
                           :is-error))
 (in-package :t.sxql)
 
-(plan 66)
+(plan 67)
 
 (defmacro is-mv (test result &optional desc)
   `(is (multiple-value-list (yield ,test))
@@ -322,6 +322,12 @@
 (is-mv (explain (select :* (from :table)) :verbose t)
        '("EXPLAIN VERBOSE SELECT * FROM `table`" nil)
        "EXPLAIN VERBOSE")
+
+(diag "alter/modify table")
+
+(is-mv (alter-table :user (rename-column :e_mail :email))
+       '("ALTER TABLE `user` RENAME COLUMN `e_mail` TO `email`" nil)
+       "ALTER TABLE RENAME COLUMN")
 
 (diag "placeholder")
 


### PR DESCRIPTION
## Status Quo
To rename a column, `CHANGE COLUMN` only works on MySQL. Whereas, developers could tend to use libraries based on [cl-dbi](https://github.com/fukamachi/cl-dbi) together with sxql. Therefore, it might be nice to support the way to rename a column in PostgreSQL and SQLite as well.
## Proposal
This pull request adds supports for RENAME COLUMN in sxql. All MySQL, PostgreSQL, and SQLite (>= 3.25.0) can run `RENAME COLUMN`, which corresponds to `rename-column` clause in this pull request.

This pull request also provided 3 related test cases.


Any comments and modifications are welcomed. Thank you! 