### PR TITLE
Update (cl-syntax:use-syntax :annot) -> (annot:enable-annot-syntax)

### DIFF
--- a/src/clause.lisp
+++ b/src/clause.lisp
@@ -17,7 +17,7 @@
 (in-package :sxql.clause)
 
 (cl-package-locks:lock-package :sxql.clause)
-(cl-syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 @export
 (defstruct (fields-clause (:include statement-clause (name ""))

--- a/src/compile.lisp
+++ b/src/compile.lisp
@@ -6,7 +6,7 @@
 (in-package :sxql.compile)
 
 (cl-package-locks:lock-package :sxql.compile)
-(cl-syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 (defgeneric find-compile-function (object))
 

--- a/src/composed-statement.lisp
+++ b/src/composed-statement.lisp
@@ -42,7 +42,7 @@
 (in-package :sxql.composed-statement)
 
 (cl-package-locks:lock-package :sxql.composed-statement)
-(cl-syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 (defparameter *clause-delimiters*
   '((fields-clause . ", ")

--- a/src/operator.lisp
+++ b/src/operator.lisp
@@ -9,7 +9,7 @@
 (in-package :sxql.operator)
 
 (cl-package-locks:lock-package :sxql.operator)
-(cl-syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 @export
 (defparameter *inside-select* nil)

--- a/src/sql-type.lisp
+++ b/src/sql-type.lisp
@@ -7,7 +7,7 @@
 (in-package :sxql.sql-type)
 
 (cl-package-locks:lock-package :sxql.sql-type)
-(cl-syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 @export
 (defparameter *quote-character* nil)

--- a/src/statement.lisp
+++ b/src/statement.lisp
@@ -34,7 +34,7 @@
 (in-package :sxql.statement)
 
 (cl-package-locks:lock-package :sxql.statement)
-(cl-syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 @export
 (defgeneric add-child (statement child))

--- a/src/sxql.lisp
+++ b/src/sxql.lisp
@@ -49,7 +49,7 @@
 (in-package :sxql)
 
 (cl-package-locks:lock-package :sxql)
-(cl-syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defun expand-op (object)


### PR DESCRIPTION
This pull request updates the use of cl-annot.

Older versions of cl-annot cause the next problem when I try to load a system that depends on it:
```
debugger invoked on a EDITOR-HINTS.NAMED-READTABLES:READER-MACRO-CONFLICT in thread
#<THREAD tid=70832 "main thread" RUNNING {10013F0073}>:
  Reader macro conflict while trying to merge the dispatch macro characters #\#
  #\R from #<NAMED-READTABLE CL-ANNOT::SYNTAX {1005F87D63}> into
  #<READTABLE {1001AD8413}>.

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [CONTINUE                     ] Overwrite #\# in #<NAMED-READTABLE :CURRENT {1001AD8413}>.
  1: [RETRY                        ] Retry
                                     compiling #<CL-SOURCE-FILE "sxql" "src" "sql-type">.
  2: [ACCEPT                       ] Continue, treating
                                     compiling #<CL-SOURCE-FILE "sxql" "src" "sql-type">
                                     as having been successful.
  3:                                 Retry ASDF operation.
  4: [CLEAR-CONFIGURATION-AND-RETRY] Retry ASDF operation after resetting the
                                     configuration.
  5:                                 Retry ASDF operation.
  6:                                 Retry ASDF operation after resetting the
                                     configuration.
  7: [ABORT                        ] Give up on "fql"
  8: [REGISTER-LOCAL-PROJECTS      ] Register local projects and try again.
  9:                                 Exit debugger, returning to top level.

(EDITOR-HINTS.NAMED-READTABLES:MERGE-READTABLES-INTO #<READTABLE {1001AD8413}> #<NAMED-READTABLE CL-ANNOT::SYNTAX {1005F87D63}>)
   source: (CHECK-READER-MACRO-CONFLICT FROM TO CHAR SUBCHAR)
```