### PR TITLE
Fix: sbcl warnings open-code test unknown type

### DIFF
--- a/src/clause.lisp
+++ b/src/clause.lisp
@@ -214,6 +214,18 @@
   (column-names nil :type sql-list)
   (references nil :type references-clause))
 
+@export
+(defstruct (column-definition-clause (:include sql-clause)
+                                     (:constructor %make-column-definition-clause (column-name &key type not-null default auto-increment autoincrement unique primary-key)))
+  column-name
+  type
+  not-null
+  default
+  auto-increment
+  autoincrement
+  unique
+  primary-key)
+
 (defstruct (column-modifier-clause (:include expression-clause)
                                    (:constructor nil))
   (column-definition nil :type column-definition-clause)
@@ -288,18 +300,6 @@
 
 (defstruct (drop-column-clause (:include expression-clause (name "DROP COLUMN"))
                                (:constructor make-drop-column-clause (expression))))
-
-@export
-(defstruct (column-definition-clause (:include sql-clause)
-                                     (:constructor %make-column-definition-clause (column-name &key type not-null default auto-increment autoincrement unique primary-key)))
-  column-name
-  type
-  not-null
-  default
-  auto-increment
-  autoincrement
-  unique
-  primary-key)
 
 @export
 (defun make-column-definition-clause (column-name &rest args &key type not-null default auto-increment autoincrement unique primary-key)

--- a/src/operator.lisp
+++ b/src/operator.lisp
@@ -52,11 +52,12 @@
 (defstruct (asc-op (:include order-op (name "ASC"))
                    (:constructor make-asc-op (var &key nulls))))
 (define-op (:distinct unary-splicing-op))
+(define-op (:= infix-op))
 (defstruct (on-op (:include sql-op (name "ON"))
                   (:constructor make-on-op (var)))
   (var nil :type =-op))
 
-(define-op (:= infix-op))
+
 (define-op (:!= infix-op))
 (define-op (:< infix-op))
 (define-op (:> infix-op))

--- a/src/sql-type.lisp
+++ b/src/sql-type.lisp
@@ -103,6 +103,19 @@
     (symbol (make-sql-keyword (string-upcase type)))
     (t type)))
 
+
+@export
+(defstruct sql-clause
+  (name "" :type string))
+
+(defun sql-clause-list-p (object)
+  (every #'sql-clause-p object))
+
+@export
+(deftype sql-clause-list ()
+  '(and proper-list
+        (satisfies sql-clause-list-p)))
+
 @export
 (deftype sql-expression () '(or sql-atom sql-list sql-op sql-clause null))
 
@@ -126,28 +139,16 @@
                                          (:constructor make-sql-splicing-expression-list (&rest elements))))
 
 @export
-(defstruct sql-clause
-  (name "" :type string))
-
-(defun sql-clause-list-p (object)
-  (every #'sql-clause-p object))
-
-@export
-(deftype sql-clause-list ()
-  '(and proper-list
-        (satisfies sql-clause-list-p)))
-
-@export
 @export-accessors
 (defstruct sql-statement
   (name "" :type string))
+
+(deftype sql-all-type () '(or sql-expression sql-statement))
 
 (defun sql-statement-list-p (object)
   (every #'(lambda (element)
              (typep element 'sql-all-type))
          object))
-
-(deftype sql-all-type () '(or sql-expression sql-statement))
 
 ;;
 ;; Operator


### PR DESCRIPTION
Rearrange the code so that types defined before first usage.

Now the code compiles without warnings on sbcl 2.4.3. 
Tests suites are still working.