### PR TITLE
Update operator.lisp to add SQLite's MATCH

### DIFF
--- a/src/operator.lisp
+++ b/src/operator.lisp
@@ -69,6 +69,7 @@
 (define-op (:in infix-list-op))
 (define-op (:not-in infix-list-op))
 (define-op (:like infix-op))
+(define-op (:match infix-op))
 (define-op (:similar-to infix-op))
 (define-op (:is-distinct-from infix-op))
 (define-op (:is-not-distinct-from infix-op))


### PR DESCRIPTION
Just wanted to add the [MATCH operator](https://www.sqlite.org/lang_expr.html) to use it for [full text search](https://www.sqlite.org/fts5.html).