### PR TITLE
Added define-compile-struct for select-query-state.

### DIFF
--- a/src/compile.lisp
+++ b/src/compile.lisp
@@ -36,6 +36,7 @@
 (define-compile-struct sql-op (name ""))
 (define-compile-struct sql-clause)
 (define-compile-struct sql-statement)
+(define-compile-struct sxql/composer:select-query-state)
 
 (defun sql-compile (object)
   (multiple-value-bind (sql bind) (yield object)


### PR DESCRIPTION
# Problem
When running this example code:

```common-lisp
(sql-compile
 (-> (from :users)
     (where (:= :id 123))))
```

I get the following error:

```
There is no applicable method for the generic function
  #<STANDARD-GENERIC-FUNCTION SXQL/COMPILE::FIND-COMPILE-FUNCTION (3)>
when called with arguments
  (#<QUERY-STATE: SELECT * FROM users WHERE (id = 123)>).
```

# Solution

Add a `define-compile-struct` definition for `sxql/composer:select-query-state`.
