### PR TITLE
Fix/sql compile

### DIFF
--- a/src/compile.lisp
+++ b/src/compile.lisp
@@ -4,7 +4,9 @@
         #:sxql/sql-type)
   (:export
    ;; Functions
-   #:sql-compile))
+   #:sql-compile)
+  (:import-from #:sxql/composer
+                #:select-query-state))
 (in-package #:sxql/compile)
 
 (cl-package-locks:lock-package '#:sxql/compile)

--- a/sxql.asd
+++ b/sxql.asd
@@ -13,8 +13,8 @@
    (:file "clause" :depends-on ("operator"))
    (:file "statement" :depends-on ("operator" "clause" "util"))
    (:file "composed-statement" :depends-on ("sql-type" "operator" "clause" "statement" "util"))
-   (:file "compile" :depends-on ("sql-type"))
    (:file "composer" :depends-on ("sql-type" "clause" "statement"))
+   (:file "compile" :depends-on ("sql-type"))
    (:file "sxql" :depends-on ("composer" "statement" "clause" "operator" "compile" "composed-statement")))
   :description "A SQL generator"
   :in-order-to ((test-op (test-op "sxql-test"))))


### PR DESCRIPTION
# Problem
When running this example code:

```common-lisp
(sql-compile
 (-> (from :users)
     (where (:= :id 123))))
```

I get the following error:

```
There is no applicable method for the generic function
  #<STANDARD-GENERIC-FUNCTION SXQL/COMPILE::FIND-COMPILE-FUNCTION (3)>
when called with arguments
  (#<QUERY-STATE: SELECT * FROM users WHERE (id = 123)>).
```

# Solution

Add a `define-compile-struct` definition for `sxql/composer:select-query-state` and move the "compile" file below the "composer" file in system definition.
